### PR TITLE
Handling filenames without extensions

### DIFF
--- a/helperlibs/bio/seqio.py
+++ b/helperlibs/bio/seqio.py
@@ -42,6 +42,9 @@ def _get_seqtype_from_ext(handle):
         modifier = 'gz-'
         dummy, ext = path.splitext(dummy)
 
+    if not ext:
+        ext = "." + dummy
+
     if ext in (".gbk", ".gb", ".genbank", ".gbff"):
         return modifier + "genbank"
     elif ext in (".embl", ".emb"):

--- a/helperlibs/tests/bio/test_seqio.py
+++ b/helperlibs/tests/bio/test_seqio.py
@@ -19,6 +19,10 @@ class TestSeqIOSeqtype(unittest.TestCase):
         handle = DummyHandle("test.%s" % extension)
         self.assertEqual(expected_type, seqio._get_seqtype_from_ext(handle))
 
+        # and test cases where the whole filename *is* the extension
+        handle = DummyHandle(extension)
+        self.assertEqual(expected_type, seqio._get_seqtype_from_ext(handle))
+
     def test__get_seqtype_from_ext(self):
         "Test guessing the sequence type from the file extension for handle input"
         genbank_extensions = ("gbk", "gb", "genbank", "gbff")

--- a/helperlibs/tests/bio/test_seqio.py
+++ b/helperlibs/tests/bio/test_seqio.py
@@ -15,37 +15,27 @@ class DummyHandle(object):
 
 
 class TestSeqIOSeqtype(unittest.TestCase):
+    def ensure_type_for_extension(self, extension, expected_type):
+        handle = DummyHandle("test.%s" % extension)
+        self.assertEqual(expected_type, seqio._get_seqtype_from_ext(handle))
+
     def test__get_seqtype_from_ext(self):
         "Test guessing the sequence type from the file extension for handle input"
-        gbk_h = DummyHandle("test.gbk")
-        gb_h = DummyHandle("test.gb")
-        genbank_h = DummyHandle("test.genbank")
-        gbff_h = DummyHandle("test.gbff")
-        embl_h = DummyHandle("test.embl")
-        emb_h = DummyHandle("test.emb")
-        fa_h = DummyHandle("test.fa")
-        fasta_h = DummyHandle("test.fasta")
-        fna_h = DummyHandle("test.fna")
-        faa_h = DummyHandle("test.faa")
-        fas_h = DummyHandle("test.fas")
-        gbk_gz_h = DummyHandle("test.gbk.gz")
-        gb_gz_h = DummyHandle("test.gb.gz")
-        genbank_gz_h = DummyHandle("test.genbank.gz")
-        gbff_gz_h = DummyHandle("test.gbff.gz")
+        genbank_extensions = ("gbk", "gb", "genbank", "gbff")
+
+        for extension in genbank_extensions:
+            self.ensure_type_for_extension(extension, "genbank")
+
+        for extension in ["embl", "emb"]:
+            self.ensure_type_for_extension(extension, "embl")
+
+        for extension in ["fa", "fasta", "fna", "faa", "fas"]:
+            self.ensure_type_for_extension(extension, "fasta")
+
+        for extension in genbank_extensions:
+            self.ensure_type_for_extension(extension + ".gz", "gz-genbank")
+
         invalid_h = DummyHandle("test.invalid")
-
-        for handle in (gbk_h, gb_h, genbank_h, gbff_h):
-            self.assertEqual("genbank", seqio._get_seqtype_from_ext(handle))
-
-        for handle in (embl_h, emb_h):
-            self.assertEqual("embl", seqio._get_seqtype_from_ext(handle))
-
-        for handle in (fa_h, fasta_h, fna_h, faa_h, fas_h):
-            self.assertEqual("fasta", seqio._get_seqtype_from_ext(handle))
-
-        for handle in (gbk_gz_h, gb_gz_h, genbank_gz_h, gbff_gz_h):
-            self.assertEqual("gz-genbank", seqio._get_seqtype_from_ext(handle))
-
         self.assertRaises(ValueError, seqio._get_seqtype_from_ext, invalid_h)
 
 


### PR DESCRIPTION
In cases where the whole filename was the intended extension (e.g. `fasta` instead of `accession.fasta`), the extension prediction fell over. This fix uses the full filename as a fallback in cases of no extension being present.